### PR TITLE
Add specs for payment processor

### DIFF
--- a/spec/student/payment_processor_spec.rb
+++ b/spec/student/payment_processor_spec.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
 describe PaymentProcessor do
-  # ...student specs...
+  let(:payment_processor) { instance_double("PaymentProcessor") }
+
+  it "stubs a method" do
+    allow(payment_processor).to receive(:process).with(100, "ABC123").and_return("processed")
+    expect(payment_processor.process(100, "ABC123")).to eq("processed")
+  end
+
+  it "verifies a method call" do
+    allow(payment_processor).to receive(:refund)
+    payment_processor.refund(50, "ABC123")
+    expect(payment_processor).to have_received(:refund).with(50, "ABC123")
+  end
 end


### PR DESCRIPTION
This pull request updates the `PaymentProcessor` spec to use RSpec's test double features. The main changes are the addition of tests that demonstrate how to stub and verify method calls on a double.

Testing improvements:

* Added a test that stubs the `process` method on a `PaymentProcessor` double and verifies the return value.
* Added a test that verifies the `refund` method was called with specific arguments on the double.