### PR TITLE
Allow for let or subject naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,24 @@ In this lab, you'll use RSpec doubles, mocks, and spies to isolate a Ruby servic
 ## Instructions
 
 1. **Write specs in `spec/student/` for the provided service object, `PaymentProcessor`.**
-   - Write at least one spec per PaymentProcessor dependency or behavior you want to test.
+        - For each external dependency or key behavior of `PaymentProcessor`, write at least one spec.
+        - **What are PaymentProcessor's dependencies?**
+            - `PaymentProcessor` depends on two objects: `gateway` (required) and `logger` (optional).
+            - `gateway` is expected to respond to `charge(amount, account)` and `refund(amount, account)`.
+            - `logger` is expected to respond to `info(message)` and `error(message)`.
+            - In your tests, you could replace both/either `gateway` and `logger` with doubles or spies.
 
-2. Use doubles to replace PaymentProcessor's external dependencies.
-   - Use `allow(...).to receive` to stub methods on your PaymentProcessor doubles.
-   - Use argument matchers like `with(...)` to ensure PaymentProcessor methods are called with the correct arguments.
+2. **Replace PaymentProcessor’s dependencies with doubles.**
+        - Use `double`, `instance_double`, or `class_double` to create test doubles for the `gateway` and `logger` dependencies.
+        - Use `allow(...).to receive(:method_name)` to stub methods on these doubles, so you can control their behavior in your tests.
+        - Use `.with(...)` to specify the exact arguments you expect these methods to be called with.
 
-3. Use mocks and spies to verify PaymentProcessor method calls and behaviors.
-   - Check that the method returns the expected result **and** that PaymentProcessor dependencies were called correctly.
-   - Use spies to check that PaymentProcessor methods are called as expected.
+3. **Verify interactions using mocks and spies.**
+     - Use `expect(...).to have_received(:method_name).with(args)` to check that your doubles were called as expected.
+     - Use `spy` if you want to record and later verify how a double was used.
+     - Make sure your specs check both:
+         - The return value of the method you’re testing.
+         - That the correct methods were called on your doubles with the correct arguments.
 
 4. Do **not** change any files in `spec/meta/`—these are lab checker specs that verify your PaymentProcessor specs. In the test output, any spec labeled with `[LAB CHECKER]` is an official lab checker (not written by you) and is there to help you know if your specs meet the requirements.
 5. Run `bin/rspec` frequently to check your progress and see which PaymentProcessor behaviors are working as expected.

--- a/lib/payment_processor.rb
+++ b/lib/payment_processor.rb
@@ -11,22 +11,24 @@ class PaymentProcessor
   def process(amount, account)
     raise ArgumentError, 'Amount must be positive' unless amount.positive?
     raise ArgumentError, 'Account required' if account.nil?
+
     result = gateway.charge(amount, account)
-    logger&.info("Charged #{amount} to #{account}") if logger
+    logger&.info("Charged #{amount} to #{account}")
     result
-  rescue => e
-    logger&.error(e.message) if logger
+  rescue StandardError => e
+    logger&.error(e.message)
     raise
   end
 
   def refund(amount, account)
     raise ArgumentError, 'Amount must be positive' unless amount.positive?
     raise ArgumentError, 'Account required' if account.nil?
+
     result = gateway.refund(amount, account)
-    logger&.info("Refunded #{amount} to #{account}") if logger
+    logger&.info("Refunded #{amount} to #{account}")
     result
-  rescue => e
-    logger&.error(e.message) if logger
+  rescue StandardError => e
+    logger&.error(e.message)
     raise
   end
 end

--- a/spec/meta/payment_processor_meta_spec.rb
+++ b/spec/meta/payment_processor_meta_spec.rb
@@ -26,7 +26,7 @@ describe '[LAB CHECKER] PaymentProcessor Doubles & Mocks Spec Requirements' do
     student_spec_files.each do |file|
       content = File.read(file)
       # Look for allow(...).to receive with PaymentProcessor or a double
-      if content.match(/allow\s*\(([^)]*PaymentProcessor[^)]*|[^)]*double[^)]*)\)\.to receive/)
+      if content.match(/allow\s*\([^)]+\)\.to receive/)
         found = true
         break
       end
@@ -39,7 +39,7 @@ describe '[LAB CHECKER] PaymentProcessor Doubles & Mocks Spec Requirements' do
     student_spec_files.each do |file|
       content = File.read(file)
       # Look for have_received or spy with PaymentProcessor
-      if content.match(/(have_received|spy).*PaymentProcessor/)
+      if content.match(/(have_received|spy).*/)
         found = true
         break
       end


### PR DESCRIPTION
This pull request mainly focuses on improving the robustness and clarity of the `PaymentProcessor` error handling and logging, as well as making the meta-spec tests for mocking more flexible. The most important changes are grouped below:

**Error Handling and Logging Improvements:**

* Updated `lib/payment_processor.rb` to consistently use `StandardError` in rescue blocks and removed unnecessary `if logger` checks, streamlining logging for both successful and error cases.

**Testing and Spec Flexibility:**

* Relaxed the regular expressions in `spec/meta/payment_processor_meta_spec.rb` to match a broader range of mocking and spying patterns, making the meta-specs less brittle and more inclusive of different test styles. [[1]](diffhunk://#diff-f62a2be0139107ee5cafc0008654139b5c7892ee74e0a048c2cb7ab0f141192cL29-R29) [[2]](diffhunk://#diff-f62a2be0139107ee5cafc0008654139b5c7892ee74e0a048c2cb7ab0f141192cL42-R42)